### PR TITLE
Remove card border

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,24 @@ It allows to group multiple cards into one card without the borders. By default,
 
 If a card inside the stack has the `--keep-background` CSS style defined, it will not replace the background. This is usefull for [button-card](https://github.com/custom-cards/button-card) for example. You can also define this CSS variable by using [card-mod](https://github.com/thomasloven/lovelace-card-mod).
 
-| Name | Type | Requirement | Description | Default |
-| ---- | ---- | ----------- | ----------- | ------- |
-| `type` | string  | **Required** | `custom:stack-in-card` | |
-| `title` | string  | **Optional** | Header of the card | |
-| `mode` | string  | **Optional** | `vertical` or `horizontal` stack | `vertical` |
-| `cards` | object  | **Required** | The cards you want to embed | `none` |
-| `keep` | object | **Optional** | See [keep object](#keep-object) | |
+| Name    | Type   | Requirement  | Description                      | Default    |
+| ------- | ------ | ------------ | -------------------------------- | ---------- |
+| `type`  | string | **Required** | `custom:stack-in-card`           |            |
+| `title` | string | **Optional** | Header of the card               |            |
+| `mode`  | string | **Optional** | `vertical` or `horizontal` stack | `vertical` |
+| `cards` | object | **Required** | The cards you want to embed      | `none`     |
+| `keep`  | object | **Optional** | See [keep object](#keep-object)  |            |
 
 ### `keep` object
 
-| Name | Type | Requirement | Description | Default |
-| ---- | ---- | ----------- | ----------- | ------- |
-| `background` | boolean | **Optional** | Will keep the background on **all** the child cards. To keep the background on specific cards only, assign the CSS variable `--keep-background: 'true'` on the card where you want to keep the background.  | `false` |
-| `box_shadow` | boolean | **Optional** | Will keep the `box-shadow` on **all** the child cards | `false` |
-| `margin` | boolean | **Optional** | Will keep the `margin` between **all** the child cards | `false` |
-| `outer_padding` | boolean | **Optional** | Will add a `padding` of `8px` to the card if `margin` is `true` | `true` if `margin` is `true`, else false |
-| `border_radius` | boolean | **Optional** | Will keep the `border-radius` on **all** the child cards | `false` |
+| Name            | Type    | Requirement  | Description                                                                                                                                                                                                | Default                                  |
+| --------------- | ------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `background`    | boolean | **Optional** | Will keep the background on **all** the child cards. To keep the background on specific cards only, assign the CSS variable `--keep-background: 'true'` on the card where you want to keep the background. | `false`                                  |
+| `box_shadow`    | boolean | **Optional** | Will keep the `box-shadow` on **all** the child cards                                                                                                                                                      | `false`                                  |
+| `margin`        | boolean | **Optional** | Will keep the `margin` between **all** the child cards                                                                                                                                                     | `false`                                  |
+| `outer_padding` | boolean | **Optional** | Will add a `padding` of `8px` to the card if `margin` is `true`                                                                                                                                            | `true` if `margin` is `true`, else false |
+| `border_radius` | boolean | **Optional** | Will keep the `border-radius` on **all** the child cards                                                                                                                                                   | `false`                                  |
+| `border`        | boolean | **Optional** | Will keep the `border` on **all** the child cards                                                                                                                                                          | `false`                                  |
 
 ## Example
 

--- a/src/stack-in-card.ts
+++ b/src/stack-in-card.ts
@@ -51,6 +51,7 @@ class StackInCard extends LitElement implements LovelaceCard {
         margin: false,
         box_shadow: false,
         border_radius: false,
+        border: false,
         ...config.keep,
       },
     };
@@ -104,6 +105,7 @@ class StackInCard extends LitElement implements LovelaceCard {
       e.style.background = 'transparent';
     }
     if (!this._config?.keep?.border_radius) e.style.borderRadius = '0';
+    if (!this._config?.keep?.border) e.style.border = 'none';
   }
 
   private _loopChildren(e: LovelaceCard, withBg: boolean): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,5 @@ export interface KeepConfig {
   box_shadow?: boolean;
   border_radius?: boolean;
   outer_padding?: boolean;
+  border?: boolean;
 }


### PR DESCRIPTION
Home Assistant `2022.11` uses border instead of box-shadow for cards.